### PR TITLE
Fixed header guard name collision in utf8.h

### DIFF
--- a/src/helpers/utf8.h
+++ b/src/helpers/utf8.h
@@ -18,8 +18,8 @@ along with XMOTO; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 =============================================================================*/
 
-#ifndef __UTF8_H__
-#define __UTF8_H__
+#ifndef __XMOTO_UTF8_H__
+#define __XMOTO_UTF8_H__
 
 #include <vector>
 #include <string>


### PR DESCRIPTION
Cherry pick from @Nikekson's fix in `master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/5)
<!-- Reviewable:end -->
