### PR TITLE
Add .desktop ArcadeGame sub-menu

### DIFF
--- a/extra/xmoto.desktop
+++ b/extra/xmoto.desktop
@@ -6,4 +6,4 @@ GenericName=Motocross game
 GenericName[fr_FR]=Jeu de moto
 Icon=xmoto.xpm
 Exec=xmoto
-Categories=Game;SportsGame;
+Categories=Game;SportsGame;ArcadeGame;


### PR DESCRIPTION
The GNOME HIG state that a submenu should have at least three items
before being used.

This is taken from
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=478974

Signed-off-by: Stephen Kitt <steve@sk2.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/13)
<!-- Reviewable:end -->
