### PR TITLE
Stop referring to sa_restorer

### DIFF
--- a/src/xmoto/GameInit.cpp
+++ b/src/xmoto/GameInit.cpp
@@ -282,12 +282,9 @@ void GameApp::run_load(int nNumArgs, char **ppcArgs) {
   if (v_xmArgs.isOptServerOnly()) {
     struct sigaction v_act;
 
+    memset(&v_act, 0, sizeof(struct sigaction));
     v_act.sa_handler = xmexit_term;
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-    v_act.sa_restorer = NULL;
-#endif
     sigemptyset(&v_act.sa_mask);
-    v_act.sa_flags = 0;
 
     if (sigaction(SIGTERM, &v_act, NULL) != 0) {
       LogWarning("sigaction failed");


### PR DESCRIPTION
sa_restorer isn't defined in POSIX and is being removed.

This was taken from
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=674636

Signed-off-by: Stephen Kitt <steve@sk2.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/17)
<!-- Reviewable:end -->
