### PR TITLE
Fix cppcheck warning, pass some strings by const&

### DIFF
--- a/src/xmoto/GameEvents.cpp
+++ b/src/xmoto/GameEvents.cpp
@@ -466,7 +466,7 @@ MGE_PlayersToucheEntity::MGE_PlayersToucheEntity(int p_eventTime)
 }
 
 MGE_PlayersToucheEntity::MGE_PlayersToucheEntity(int p_eventTime,
-                                                 std::string p_entityID,
+                                                 const std::string& p_entityID,
                                                  bool p_bTouchedWithHead)
   : SceneEvent(p_eventTime) {
   m_entityID = p_entityID;
@@ -506,7 +506,7 @@ MGE_PlayerTouchesEntity::MGE_PlayerTouchesEntity(int p_eventTime)
 }
 
 MGE_PlayerTouchesEntity::MGE_PlayerTouchesEntity(int p_eventTime,
-                                                 std::string p_entityID,
+                                                 const std::string& p_entityID,
                                                  bool p_bTouchedWithHead,
                                                  int i_player)
   : SceneEvent(p_eventTime) {
@@ -552,7 +552,7 @@ MGE_EntityDestroyed::MGE_EntityDestroyed(int p_eventTime)
 }
 
 MGE_EntityDestroyed::MGE_EntityDestroyed(int p_eventTime,
-                                         std::string i_entityId,
+                                         const std::string& i_entityId,
                                          EntitySpeciality i_entityType,
                                          Vector2f i_entityPosition,
                                          float i_entitySize,
@@ -794,7 +794,7 @@ MGE_Message::MGE_Message(int p_eventTime)
   m_message = "";
 }
 
-MGE_Message::MGE_Message(int p_eventTime, std::string p_message)
+MGE_Message::MGE_Message(int p_eventTime, const std::string& p_message)
   : SceneEvent(p_eventTime) {
   m_message = p_message;
 }
@@ -836,7 +836,7 @@ MGE_MoveBlock::MGE_MoveBlock(int p_eventTime)
 }
 
 MGE_MoveBlock::MGE_MoveBlock(int p_eventTime,
-                             std::string p_blockID,
+                             const std::string& p_blockID,
                              float p_x,
                              float p_y)
   : SceneEvent(p_eventTime) {
@@ -885,7 +885,7 @@ MGE_SetBlockPos::MGE_SetBlockPos(int p_eventTime)
 }
 
 MGE_SetBlockPos::MGE_SetBlockPos(int p_eventTime,
-                                 std::string p_blockID,
+                                 const std::string& p_blockID,
                                  float p_x,
                                  float p_y)
   : SceneEvent(p_eventTime) {
@@ -1085,7 +1085,7 @@ MGE_SetEntityPos::MGE_SetEntityPos(int p_eventTime)
 }
 
 MGE_SetEntityPos::MGE_SetEntityPos(int p_eventTime,
-                                   std::string p_entityID,
+                                   const std::string& p_entityID,
                                    float p_x,
                                    float p_y)
   : SceneEvent(p_eventTime) {
@@ -1134,7 +1134,7 @@ MGE_SetBlockCenter::MGE_SetBlockCenter(int p_eventTime)
 }
 
 MGE_SetBlockCenter::MGE_SetBlockCenter(int p_eventTime,
-                                       std::string p_blockID,
+                                       const std::string& p_blockID,
                                        float p_x,
                                        float p_y)
   : SceneEvent(p_eventTime) {
@@ -1182,7 +1182,7 @@ MGE_SetBlockRotation::MGE_SetBlockRotation(int p_eventTime)
 }
 
 MGE_SetBlockRotation::MGE_SetBlockRotation(int p_eventTime,
-                                           std::string p_blockID,
+                                           const std::string& p_blockID,
                                            float p_angle)
   : SceneEvent(p_eventTime) {
   m_blockID = p_blockID;
@@ -1231,7 +1231,7 @@ MGE_SetDynamicEntityRotation::MGE_SetDynamicEntityRotation(int p_eventTime)
 
 MGE_SetDynamicEntityRotation::MGE_SetDynamicEntityRotation(
   int p_eventTime,
-  std::string p_entityID,
+  const std::string& p_entityID,
   float p_fInitAngle,
   float p_fRadius,
   int p_period,
@@ -1302,7 +1302,7 @@ MGE_SetDynamicEntityTranslation::MGE_SetDynamicEntityTranslation(
 
 MGE_SetDynamicEntityTranslation::MGE_SetDynamicEntityTranslation(
   int p_eventTime,
-  std::string p_entityID,
+  const std::string& p_entityID,
   float p_x,
   float p_y,
   int p_period,
@@ -1366,7 +1366,7 @@ MGE_SetDynamicEntityNone::MGE_SetDynamicEntityNone(int p_eventTime)
 }
 
 MGE_SetDynamicEntityNone::MGE_SetDynamicEntityNone(int p_eventTime,
-                                                   std::string p_entityID)
+                                                   const std::string& p_entityID)
   : SceneEvent(p_eventTime) {
   m_entityID = p_entityID;
 }
@@ -1410,7 +1410,7 @@ MGE_SetDynamicBlockRotation::MGE_SetDynamicBlockRotation(int p_eventTime)
 }
 
 MGE_SetDynamicBlockRotation::MGE_SetDynamicBlockRotation(int p_eventTime,
-                                                         std::string p_blockID,
+                                                         const std::string& p_blockID,
                                                          float p_fInitAngle,
                                                          float p_fRadius,
                                                          int p_period,
@@ -1480,7 +1480,7 @@ MGE_SetDynamicBlockTranslation::MGE_SetDynamicBlockTranslation(int p_eventTime)
 
 MGE_SetDynamicBlockTranslation::MGE_SetDynamicBlockTranslation(
   int p_eventTime,
-  std::string p_blockID,
+  const std::string& p_blockID,
   float p_x,
   float p_y,
   int p_period,
@@ -1545,7 +1545,7 @@ MGE_SetDynamicBlockNone::MGE_SetDynamicBlockNone(int p_eventTime)
 }
 
 MGE_SetDynamicBlockNone::MGE_SetDynamicBlockNone(int p_eventTime,
-                                                 std::string p_blockID)
+                                                 const std::string& p_blockID)
   : SceneEvent(p_eventTime) {
   m_blockID = p_blockID;
 }
@@ -1762,7 +1762,7 @@ MGE_SetDynamicBlockSelfRotation::MGE_SetDynamicBlockSelfRotation(
 
 MGE_SetDynamicBlockSelfRotation::MGE_SetDynamicBlockSelfRotation(
   int p_eventTime,
-  std::string p_blockID,
+  const std::string& p_blockID,
   int p_period,
   int p_startTime,
   int p_endTime)
@@ -1823,7 +1823,7 @@ MGE_SetPhysicsBlockSelfRotation::MGE_SetPhysicsBlockSelfRotation(int eventTime)
 
 MGE_SetPhysicsBlockSelfRotation::MGE_SetPhysicsBlockSelfRotation(
   int eventTime,
-  std::string blockID,
+  const std::string& blockID,
   int torque,
   int startTime,
   int endTime)
@@ -1879,7 +1879,7 @@ MGE_SetPhysicsBlockTranslation::MGE_SetPhysicsBlockTranslation(int eventTime)
 
 MGE_SetPhysicsBlockTranslation::MGE_SetPhysicsBlockTranslation(
   int eventTime,
-  std::string blockID,
+  const std::string& blockID,
   float x,
   float y,
   int period,
@@ -1949,7 +1949,7 @@ MGE_SetDynamicEntitySelfRotation::MGE_SetDynamicEntitySelfRotation(
 
 MGE_SetDynamicEntitySelfRotation::MGE_SetDynamicEntitySelfRotation(
   int p_eventTime,
-  std::string p_entityID,
+  const std::string& p_entityID,
   int p_period,
   int p_startTime,
   int p_endTime)
@@ -2177,7 +2177,7 @@ MGE_PlaySound::MGE_PlaySound(int p_eventTime)
 }
 
 MGE_PlaySound::MGE_PlaySound(int p_eventTime,
-                             std::string p_name,
+                             const std::string& p_name,
                              float p_volume)
   : SceneEvent(p_eventTime) {
   m_soundName = p_name;
@@ -2229,7 +2229,7 @@ MGE_PlayMusic::MGE_PlayMusic(int p_eventTime)
   m_musicName = "";
 }
 
-MGE_PlayMusic::MGE_PlayMusic(int p_eventTime, std::string p_name)
+MGE_PlayMusic::MGE_PlayMusic(int p_eventTime, const std::string& p_name)
   : SceneEvent(p_eventTime) {
   m_musicName = p_name;
 }

--- a/src/xmoto/GameEvents.h
+++ b/src/xmoto/GameEvents.h
@@ -248,7 +248,7 @@ class MGE_PlayersToucheEntity : public SceneEvent {
 public:
   MGE_PlayersToucheEntity(int p_eventTime);
   MGE_PlayersToucheEntity(int p_eventTime,
-                          std::string p_entityID,
+                          const std::string& p_entityID,
                           bool p_bTouchedWithHead);
   ~MGE_PlayersToucheEntity();
 
@@ -269,7 +269,7 @@ class MGE_PlayerTouchesEntity : public SceneEvent {
 public:
   MGE_PlayerTouchesEntity(int p_eventTime);
   MGE_PlayerTouchesEntity(int p_eventTime,
-                          std::string p_entityID,
+                          const std::string& p_entityID,
                           bool p_bTouchedWithHead,
                           int i_player);
   ~MGE_PlayerTouchesEntity();
@@ -293,7 +293,7 @@ public:
   MGE_EntityDestroyed(int p_eventTime);
   MGE_EntityDestroyed(
     int p_eventTime,
-    std::string i_entityId,
+    const std::string& i_entityId,
     EntitySpeciality i_entityType,
     Vector2f i_entityPosition,
     float i_entitySize,
@@ -393,7 +393,7 @@ private:
 class MGE_Message : public SceneEvent {
 public:
   MGE_Message(int p_eventTime);
-  MGE_Message(int p_eventTime, std::string p_message);
+  MGE_Message(int p_eventTime, const std::string& p_message);
   ~MGE_Message();
 
   void doAction(Scene *p_pScene);
@@ -411,7 +411,7 @@ private:
 class MGE_MoveBlock : public SceneEvent {
 public:
   MGE_MoveBlock(int p_eventTime);
-  MGE_MoveBlock(int p_eventTime, std::string p_blockID, float p_x, float p_y);
+  MGE_MoveBlock(int p_eventTime, const std::string& p_blockID, float p_x, float p_y);
   ~MGE_MoveBlock();
 
   void doAction(Scene *p_pScene);
@@ -430,7 +430,7 @@ private:
 class MGE_SetBlockPos : public SceneEvent {
 public:
   MGE_SetBlockPos(int p_eventTime);
-  MGE_SetBlockPos(int p_eventTime, std::string p_blockID, float p_x, float p_y);
+  MGE_SetBlockPos(int p_eventTime, const std::string& p_blockID, float p_x, float p_y);
   ~MGE_SetBlockPos();
 
   void doAction(Scene *p_pScene);
@@ -535,7 +535,7 @@ class MGE_SetEntityPos : public SceneEvent {
 public:
   MGE_SetEntityPos(int p_eventTime);
   MGE_SetEntityPos(int p_eventTime,
-                   std::string p_entityID,
+                   const std::string& p_entityID,
                    float p_x,
                    float p_y);
   ~MGE_SetEntityPos();
@@ -557,7 +557,7 @@ class MGE_SetBlockCenter : public SceneEvent {
 public:
   MGE_SetBlockCenter(int p_eventTime);
   MGE_SetBlockCenter(int p_eventTime,
-                     std::string p_blockID,
+                     const std::string& p_blockID,
                      float p_x,
                      float p_y);
   ~MGE_SetBlockCenter();
@@ -578,7 +578,7 @@ private:
 class MGE_SetBlockRotation : public SceneEvent {
 public:
   MGE_SetBlockRotation(int p_eventTime);
-  MGE_SetBlockRotation(int p_eventTime, std::string p_blockID, float p_angle);
+  MGE_SetBlockRotation(int p_eventTime, const std::string& p_blockID, float p_angle);
   ~MGE_SetBlockRotation();
 
   void doAction(Scene *p_pScene);
@@ -598,7 +598,7 @@ class MGE_SetDynamicBlockSelfRotation : public SceneEvent {
 public:
   MGE_SetDynamicBlockSelfRotation(int p_eventTime);
   MGE_SetDynamicBlockSelfRotation(int p_eventTime,
-                                  std::string p_blockID,
+                                  const std::string& p_blockID,
                                   int p_period,
                                   int p_startTime,
                                   int p_endTime);
@@ -624,7 +624,7 @@ class MGE_SetPhysicsBlockSelfRotation : public SceneEvent {
 public:
   MGE_SetPhysicsBlockSelfRotation(int eventTime);
   MGE_SetPhysicsBlockSelfRotation(int eventTime,
-                                  std::string blockID,
+                                  const std::string& blockID,
                                   int torque,
                                   int startTime,
                                   int endTime);
@@ -650,7 +650,7 @@ class MGE_SetPhysicsBlockTranslation : public SceneEvent {
 public:
   MGE_SetPhysicsBlockTranslation(int eventTime);
   MGE_SetPhysicsBlockTranslation(int eventTime,
-                                 std::string blockID,
+                                 const std::string& blockID,
                                  float x,
                                  float y,
                                  int period,
@@ -678,7 +678,7 @@ class MGE_SetDynamicEntityRotation : public SceneEvent {
 public:
   MGE_SetDynamicEntityRotation(int p_eventTime);
   MGE_SetDynamicEntityRotation(int p_eventTime,
-                               std::string p_entityID,
+                               const std::string& p_entityID,
                                float p_fInitAngle,
                                float p_fRadius,
                                int p_period,
@@ -707,7 +707,7 @@ class MGE_SetDynamicEntitySelfRotation : public SceneEvent {
 public:
   MGE_SetDynamicEntitySelfRotation(int p_eventTime);
   MGE_SetDynamicEntitySelfRotation(int p_eventTime,
-                                   std::string p_entityID,
+                                   const std::string& p_entityID,
                                    int p_period,
                                    int p_startTime,
                                    int p_endTime);
@@ -733,7 +733,7 @@ class MGE_SetDynamicEntityTranslation : public SceneEvent {
 public:
   MGE_SetDynamicEntityTranslation(int p_eventTime);
   MGE_SetDynamicEntityTranslation(int p_eventTime,
-                                  std::string p_entityID,
+                                  const std::string& p_entityID,
                                   float p_x,
                                   float p_y,
                                   int p_period,
@@ -760,7 +760,7 @@ private:
 class MGE_SetDynamicEntityNone : public SceneEvent {
 public:
   MGE_SetDynamicEntityNone(int p_eventTime);
-  MGE_SetDynamicEntityNone(int p_eventTime, std::string p_entityID);
+  MGE_SetDynamicEntityNone(int p_eventTime, const std::string& p_entityID);
   ~MGE_SetDynamicEntityNone();
 
   void doAction(Scene *p_pScene);
@@ -779,7 +779,7 @@ class MGE_SetDynamicBlockRotation : public SceneEvent {
 public:
   MGE_SetDynamicBlockRotation(int p_eventTime);
   MGE_SetDynamicBlockRotation(int p_eventTime,
-                              std::string p_blockID,
+                              const std::string& p_blockID,
                               float p_fInitAngle,
                               float p_fRadius,
                               int p_period,
@@ -809,7 +809,7 @@ class MGE_SetDynamicBlockTranslation : public SceneEvent {
 public:
   MGE_SetDynamicBlockTranslation(int p_eventTime);
   MGE_SetDynamicBlockTranslation(int p_eventTime,
-                                 std::string p_blockID,
+                                 const std::string& p_blockID,
                                  float p_x,
                                  float p_y,
                                  int p_period,
@@ -836,7 +836,7 @@ private:
 class MGE_SetDynamicBlockNone : public SceneEvent {
 public:
   MGE_SetDynamicBlockNone(int p_eventTime);
-  MGE_SetDynamicBlockNone(int p_eventTime, std::string p_blockID);
+  MGE_SetDynamicBlockNone(int p_eventTime, const std::string& p_blockID);
   ~MGE_SetDynamicBlockNone();
 
   void doAction(Scene *p_pScene);
@@ -979,7 +979,7 @@ class MGE_PlaySound : public SceneEvent {
 public:
   MGE_PlaySound(int p_eventTime);
   MGE_PlaySound(int p_eventTime,
-                std::string p_soundName,
+                const std::string& p_soundName,
                 float p_volume = DEFAULT_SAMPLE_VOLUME);
   ~MGE_PlaySound();
 
@@ -999,7 +999,7 @@ private:
 class MGE_PlayMusic : public SceneEvent {
 public:
   MGE_PlayMusic(int p_eventTime);
-  MGE_PlayMusic(int p_eventTime, std::string p_musicName);
+  MGE_PlayMusic(int p_eventTime, const std::string& p_musicName);
   ~MGE_PlayMusic();
 
   void doAction(Scene *p_pScene);


### PR DESCRIPTION
This fixes some cppcheck performance warnings for GameEvents.cpp and GameEvents.h saying "Function parameter such-and-such should be passed by const reference."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/21)
<!-- Reviewable:end -->
