### PR TITLE
Fix leaking the download replays thread in StateManager.

### DIFF
--- a/src/states/StateManager.cpp
+++ b/src/states/StateManager.cpp
@@ -133,6 +133,7 @@ StateManager::~StateManager() {
     if (m_drt->waitForThreadEnd()) {
       LogError("replays downloader thread failed");
     }
+    delete m_drt;
   }
 
   deleteToDeleteState();


### PR DESCRIPTION
Running X-Moto in Valgrind 3.14.0 produces the following warning (there were others, but this was the biggest leak of a single run of X-Moto in Valgrind that didn't have a bunch of `???` frames):

```
==4999== 188,221 (256 direct, 187,965 indirect) bytes in 1 blocks are definitely lost in loss record 1,672 of 1,673
==4999==    at 0x4C2E91F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==4999==    by 0x50F11B: StateManager::StateManager() (StateManager.cpp:102)
==4999==    by 0x4B876B: Singleton<StateManager>::instance() (Singleton.h:33)
==4999==    by 0x58E6DA: GameApp::run_load(int, char**) (GameInit.cpp:403)
==4999==    by 0x58CFF8: GameApp::run(int, char**) (GameInit.cpp:158)
==4999==    by 0x58CE1C: main (GameInit.cpp:117)
==4999==    
```
This leak only happens once per run of X-Moto (when X-Moto is closed). The fix is to delete `m_drt` after the thread exits. However, it might still leak if the thread fails to end; this depends on whether the `LogError` call causes the program to exit before deleting `m_drt`.

I ran it under Valgrind with `valgrind --leak-check=full src/xmoto` from a directory named `build` (where I compiled X-Moto with `cmake -DCMAKE_BUILD_TYPE=Debug ..`) in my local copy of the X-Moto git repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/32)
<!-- Reviewable:end -->
