### PR TITLE
Fix leaking the ghost replay file.

### DIFF
--- a/src/xmscene/BikeGhost.cpp
+++ b/src/xmscene/BikeGhost.cpp
@@ -109,6 +109,7 @@ FileGhost::~FileGhost() {
   for (unsigned int i = 0; i < m_ghostBikeStates.size(); i++) {
     delete m_ghostBikeStates[i];
   }
+  delete m_replay;
 }
 
 void FileGhost::execReplayEvents(int i_time, Scene *i_motogame) {


### PR DESCRIPTION
Like #32 this is another small change that fixes a leak. I didn't notice this leak at first because I didn't test out the replay functionality under Valgrind before.

The Replay `m_replay` was created (with `new`) in the constructor of `FileGhost` but was never deleted in the destructor; this causes the replay file not to be freed (the `Replay` destructor would have freed the file with `Replay::_FreeReplay`). Deleting the m_replay in FileGhost's destructor should free the file.

`Valgrind --fullpath-after=/mnt/d/Linux_home/nathan/src/xmoto-git/ --undef-value-errors=no --leak-check=full --show-leak-kinds=definite build/src/xmoto`

```
...
==472== 9,260 (304 direct, 8,956 indirect) bytes in 1 blocks are definitely lost in loss record 1,763 of 1,768
==472==    at 0x4C2E91F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==472==    by 0x5FDC00: FileGhost::FileGhost(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, PhysicsSettings*, bool, bool, Theme*, BikerTheme*, TColor const&, TColor const&) (src/xmscene/BikeGhost.cpp:87)
==472==    by 0x5FFF6A: ReplayBiker::ReplayBiker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, PhysicsSettings*, bool, Theme*, BikerTheme*) (src/xmscene/BikeGhost.cpp:522)
==472==    by 0x636579: Scene::addReplayFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Theme*, BikerTheme*, bool) (src/xmscene/Scene.cpp:669)
==472==    by 0x547525: StatePreplayingReplay::initPlayers() (src/states/StatePreplayingReplay.cpp:74)
==472==    by 0x542CB8: StatePreplaying::enter() (src/states/StatePreplaying.cpp:142)
==472==    by 0x50F6BC: StateManager::pushState(GameState*) (src/states/StateManager.cpp:185)
==472==    by 0x4D4A98: StateDeadMenu::checkEvents() (src/states/StateDeadMenu.cpp:149)
==472==    by 0x517115: StateMenu::xmKey(InputEventType, XMKey const&) (src/states/StateMenu.cpp:123)
==472==    by 0x4D5F18: StateDeadMenu::xmKey(InputEventType, XMKey const&) (src/states/StateDeadMenu.cpp:271)
==472==    by 0x512151: StateManager::xmKey(InputEventType, XMKey const&) (src/states/StateManager.cpp:810)
==472==    by 0x590E7F: GameApp::manageEvent(SDL_Event*) (src/xmoto/GameInit.cpp:783)
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/33)
<!-- Reviewable:end -->
