### PR TITLE
A few small leak fixes

### DIFF
--- a/src/drawlib/DrawLibOpenGL.cpp
+++ b/src/drawlib/DrawLibOpenGL.cpp
@@ -190,6 +190,9 @@ DrawLibOpenGL::~DrawLibOpenGL() {
   if (m_fontMonospace != NULL) {
     delete m_fontMonospace;
   }
+  if (m_menuCamera != NULL) {
+    delete m_menuCamera;
+  }
 }
 
 DrawLibOpenGL::DrawLibOpenGL()

--- a/src/xmoto/Game.cpp
+++ b/src/xmoto/Game.cpp
@@ -547,6 +547,7 @@ void GameApp::addReplay(const std::string &i_file,
     delete rplInfos;
     throw e2;
   }
+  delete rplInfos;
 }
 
 void GameApp::setSpecificReplay(const std::string &i_replay) {

--- a/src/xmoto/Sound.cpp
+++ b/src/xmoto/Sound.cpp
@@ -182,6 +182,7 @@ SoundSample *Sound::loadSample(const std::string &File) {
 
   /* Close file */
   XMFS::closeFile(pf);
+  SDL_FreeRW(pOps);
 
   m_Samples.push_back(pSample);
   return pSample;


### PR DESCRIPTION
This pull request fixes the following tiny leaks:
- an `RWops` structure (64 byte leak) in `Sound::loadSample` that leaked 18 times.
- the replay info (104 byte leak)
- the never deleted m_menuCamera (208 byte leak)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/35)
<!-- Reviewable:end -->
