### PR TITLE
Fix #36: Invalid read of size 4 after playing replay.

### DIFF
--- a/src/drawlib/DrawLib.cpp
+++ b/src/drawlib/DrawLib.cpp
@@ -112,6 +112,7 @@ DrawLib::DrawLib() {
   m_bFBOSupported = false;
   m_texture = NULL;
   m_blendMode = BLEND_MODE_NONE;
+  m_ownsRenderSurface = false;
 
   m_fontSmall = NULL;
   m_fontMedium = NULL;
@@ -119,7 +120,10 @@ DrawLib::DrawLib() {
   m_fontMonospace = NULL;
 };
 
-DrawLib::~DrawLib() {}
+DrawLib::~DrawLib() {
+  if (m_ownsRenderSurface)
+    delete m_renderSurf;
+}
 
 FontManager *DrawLib::getFontManager(const std::string &i_fontFile,
                                      unsigned int i_fontSize,
@@ -373,8 +377,11 @@ void DrawLib::drawCircle(const Vector2f &Center,
     setBlendMode(BLEND_MODE_NONE);
 }
 
-void DrawLib::setRenderSurface(RenderSurface *renderSurf) {
+void DrawLib::setRenderSurface(RenderSurface *renderSurf, bool i_own) {
+  if (m_renderSurf != renderSurf && m_ownsRenderSurface)
+    delete m_renderSurf;
   m_renderSurf = renderSurf;
+  m_ownsRenderSurface = i_own;
 }
 
 RenderSurface *DrawLib::getRenderSurface() {

--- a/src/drawlib/DrawLib.h
+++ b/src/drawlib/DrawLib.h
@@ -145,7 +145,7 @@ public:
   void setNoGraphics(bool disable_graphics);
   bool isNoGraphics();
 
-  void setRenderSurface(RenderSurface *renderSurf);
+  void setRenderSurface(RenderSurface *renderSurf, bool i_own);
   RenderSurface *getRenderSurface();
 
   /* Methods - low-level */
@@ -321,6 +321,7 @@ protected:
   SDL_Surface *m_screen;
   Camera *m_menuCamera;
   RenderSurface *m_renderSurf;
+  bool m_ownsRenderSurface;
 
 private:
   static backendtype m_backend;

--- a/src/xmscene/Camera.cpp
+++ b/src/xmscene/Camera.cpp
@@ -75,7 +75,10 @@ Camera::Camera(Vector2i downleft, Vector2i upright) {
   prepareForNewLevel();
 }
 
-Camera::~Camera() {}
+Camera::~Camera() {
+  DrawLib *drawLib = GameApp::instance()->getDrawLib();
+  drawLib->setRenderSurface(new RenderSurface(m_renderSurf.downleft(), m_renderSurf.upright()), true);
+}
 
 void Camera::prepareForNewLevel() {
   m_fCurrentHorizontalScrollShift = 0.0f;
@@ -655,7 +658,7 @@ Biker *Camera::getPlayerToFollow() {
 
 void Camera::activate() {
   DrawLib *drawLib = GameApp::instance()->getDrawLib();
-  drawLib->setRenderSurface(&m_renderSurf);
+  drawLib->setRenderSurface(&m_renderSurf, false);
 }
 
 void Camera::setCamera2d() {


### PR DESCRIPTION
When the camera is deleted, its `m_renderSurf` is still referenced from DrawLib. Camera's `m_renderSurf` is invalid after it is deleted, so DrawLib's `m_renderSurf` is rendered invalid. To fix this, I added a boolean parameter to `setRenderSurface` which tells DrawLib whether it owns the pointer. This boolean is set when creating a new RenderSurface in the `setRenderSurface()` call, and not when passing a pointer to the `m_renderSurf` inside of Camera.

This seems to fix the "Invalid read of size 4" mentioned in issue #36.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/37)
<!-- Reviewable:end -->
