### PR TITLE
Use a default scale of 1/1 for jpeg

### DIFF
--- a/src/image/tim_jpeg.cpp
+++ b/src/image/tim_jpeg.cpp
@@ -632,6 +632,10 @@ int tim_jpeg_load(tim_session_t *pSession,
       ci.scale_num = 1;
       ci.scale_denom = 8;
       break;
+    default: /* Scale by 1/1 */
+      ci.scale_num = 1;
+      ci.scale_denom = 1;
+      break;
   }
 
   if (tim_is_hint(pSession, ".jpg", "jpeg_no_fancy_upsampling")) {


### PR DESCRIPTION
Fixes a bug I ran across with MXE builds where jpeg textures were being scaled by 8x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/45)
<!-- Reviewable:end -->
