### PR TITLE
Fix type for string index

### DIFF
--- a/src/xmoto/XMKey.cpp
+++ b/src/xmoto/XMKey.cpp
@@ -96,7 +96,7 @@ XMKey::XMKey(std::string *i_joyId, Uint8 i_joyAxis, Sint16 i_joyAxisValue) {
 }
 
 XMKey::XMKey(const std::string &i_key, bool i_basicMode) {
-  unsigned int pos;
+  size_t pos;
   std::string v_current, v_rest;
 
   m_repetition = 1;


### PR DESCRIPTION
Fixes warnings and probably incorrectly working code as unsigned int cannot be compared to string::npos