### PR TITLE
Take unordered_map from std namespace

### DIFF
--- a/src/include/xm_hashmap.h
+++ b/src/include/xm_hashmap.h
@@ -1,6 +1,6 @@
 #ifndef __XMHASHMAP_H__
 #define __XMHASHMAP_H__
 
-#include <tr1/unordered_map>
-namespace HashNamespace = std::tr1;
+#include <unordered_map>
+namespace HashNamespace = std;
 #endif


### PR DESCRIPTION
There's no `std::tr1` with e.g. libc++. Let's switch this bit to proper C++11 finally.