### PR TITLE
Fix formatting messages with player number

### DIFF
--- a/src/xmoto/GameEvents.cpp
+++ b/src/xmoto/GameEvents.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "xmscene/Camera.h"
 #include "xmscene/Level.h"
 #include <sstream>
+#include <string>
 
 SceneEvent::SceneEvent(int p_eventTime) {
   m_eventTime = p_eventTime;
@@ -1073,7 +1074,7 @@ GameEventType MGE_SetPlayerPosition::getType() {
 }
 
 std::string MGE_SetPlayerPosition::toString() {
-  return "Teleportation of the player " + m_player;
+  return "Teleportation of the player " + std::to_string(m_player);
 }
 
 //////////////////////////////
@@ -2126,7 +2127,7 @@ GameEventType MGE_AddForceToPlayer::getType() {
 }
 
 std::string MGE_AddForceToPlayer::toString() {
-  return "Add force to the player " + m_player;
+  return "Add force to the player " + std::to_string(m_player);
 }
 
 //////////////////////////////


### PR DESCRIPTION
The current implementation behaves incorrectly, effectively trimming start of message string by a number of characters equal to player number. Explicitly stringify player number to fix the behavior.