### PR TITLE
Add missing curl include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,6 +381,7 @@ target_include_directories(xmoto
   PRIVATE
 
   "${PROJECT_SOURCE_DIR}/src"
+  "${CURL_INCLUDE_DIR}"
   "${LIBXML2_INCLUDE_DIR}"
   "$<${USE_SYSTEM_Lua}:${LUA_INCLUDE_DIR}>"
   "$<$<NOT:${USE_SYSTEM_Lua}>:${PROJECT_SOURCE_DIR}/vendor/lua/lua>"


### PR DESCRIPTION
This is likely incomplete (you generally need corresponding include directory for each target_link_libraries entry), but works for me