### PR TITLE
Fix conditional jump or move errors from Valgrind

### DIFF
--- a/src/drawlib/DrawLib.cpp
+++ b/src/drawlib/DrawLib.cpp
@@ -114,6 +114,9 @@ DrawLib::DrawLib() {
   m_texture = NULL;
   m_blendMode = BLEND_MODE_NONE;
   m_ownsRenderSurface = false;
+  m_renderSurf = NULL;
+  m_screen = NULL;
+  m_menuCamera = NULL;
 
   m_fontSmall = NULL;
   m_fontMedium = NULL;

--- a/src/xmscene/Camera.cpp
+++ b/src/xmscene/Camera.cpp
@@ -72,6 +72,7 @@ Camera::Camera(Vector2i downleft, Vector2i upright) {
   m_ghostTrail = NULL;
   m_trailAvailable = false;
   m_useTrailCam = false;
+  m_catchTrail = false;
   prepareForNewLevel();
 }
 

--- a/src/xmscene/Camera.cpp
+++ b/src/xmscene/Camera.cpp
@@ -73,6 +73,7 @@ Camera::Camera(Vector2i downleft, Vector2i upright) {
   m_trailAvailable = false;
   m_useTrailCam = false;
   m_catchTrail = false;
+  m_trackingShotActivated = false;
   prepareForNewLevel();
 }
 


### PR DESCRIPTION
m_renderSurf was uninitialized when the first call to DrawLib::setRenderSurface
was made. This caused Valgrind to complain "Conditional jump or move depends on uninitialised value(s)" and 'monitor get_vbits <address of m_renderSurf> 8' in gdb to output ffffffff ffffffff

To fix this simply add m_renderSurf = NULL in the DrawLib constructor.

==868== Conditional jump or move depends on uninitialised value(s)
==868==    at 0x47669B: DrawLib::setRenderSurface(RenderSurface*, bool) (DrawLib.cpp:413)
==868==    by 0x61975D: Camera::activate() (Camera.cpp:661)
==868==    by 0x61987F: Camera::setCamera2d() (Camera.cpp:677)
==868==    by 0x478377: DrawLibOpenGL::init(unsigned int, unsigned int, unsigned int, bool) (DrawLibOpenGL.cpp:346)
==868==    by 0x58EA0A: GameApp::run_load(int, char**) (GameInit.cpp:372)
==868==    by 0x58D60A: GameApp::run(int, char**) (GameInit.cpp:158)
==868==    by 0x58D42E: main (GameInit.cpp:117)

The second error is in Camera::setScroll:

==1444== Conditional jump or move depends on uninitialised value(s)
==1444==    at 0x618FFC: Camera::setScroll(bool, Vector2<float> const&) (Camera.cpp:544)
==1444==    by 0x546975: StatePreplayingGame::initPlayers() (StatePreplayingGame.cpp:98)
==1444==    by 0x543088: StatePreplaying::enter() (StatePreplaying.cpp:142)
==1444==    by 0x50FA8C: StateManager::pushState(GameState*) (StateManager.cpp:185)
==1444==    by 0x4FAAB1: StateMainMenu::checkEventsMainWindow() (StateMainMenu.cpp:347)
==1444==    by 0x4FA75F: StateMainMenu::checkEvents() (StateMainMenu.cpp:290)
==1444==    by 0x5174E5: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:123)
==1444==    by 0x4FE72D: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==1444==    by 0x512521: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:810)
==1444==    by 0x591481: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:783)
==1444==    by 0x591938: GameApp::run_loop() (GameInit.cpp:875)
==1444==    by 0x58D63A: GameApp::run(int, char**) (GameInit.cpp:159)

Line 544 of Camera.cpp is:

544       if (!m_catchTrail && m_recenter_camera_fast) {

m_catchTrail is uninitialized, so initialized it to false in Camera constructor.

The third error is in Camera::guessDesiredCameraPosition:
==1638== Conditional jump or move depends on uninitialised value(s)
==1638==    at 0x618A1C: Camera::guessDesiredCameraPosition(float&, float&, Vector2<float> const&) (Camera.cpp:431)
==1638==    by 0x619435: Camera::setScroll(bool, Vector2<float> const&) (Camera.cpp:603)
==1638==    by 0x546975: StatePreplayingGame::initPlayers() (StatePreplayingGame.cpp:98)
==1638==    by 0x543088: StatePreplaying::enter() (StatePreplaying.cpp:142)
==1638==    by 0x50FA8C: StateManager::pushState(GameState*) (StateManager.cpp:185)
==1638==    by 0x4FAAB1: StateMainMenu::checkEventsMainWindow() (StateMainMenu.cpp:347)
==1638==    by 0x4FA75F: StateMainMenu::checkEvents() (StateMainMenu.cpp:290)
==1638==    by 0x5174E5: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:123)
==1638==    by 0x4FE72D: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==1638==    by 0x512521: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:810)
==1638==    by 0x591481: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:783)
==1638==    by 0x591938: GameApp::run_loop() (GameInit.cpp:875)

Line 431 of Camera.cpp is:
431       } else if (!m_trackingShotActivated) { // default, trail cam inactive 

m_trackingShotActivated is not initialized.