### PR TITLE
Fix 192 byte leak in createRoomsList

### DIFF
--- a/src/states/StateOptions.cpp
+++ b/src/states/StateOptions.cpp
@@ -2828,6 +2828,9 @@ void StateOptions::cleanRoomsList(UIList *pList) {
 void StateOptions::cleanRoomsList() {
   UIList *v_list;
   std::string v_tabId;
+  // no GUI when run with --pack
+  if (!m_sGUI)
+    return;
   for (unsigned int i = 0; i < ROOMS_NB_MAX; i++) {
     std::ostringstream v_strRoom;
     v_strRoom << i;

--- a/src/states/StateOptions.cpp
+++ b/src/states/StateOptions.cpp
@@ -82,6 +82,7 @@ void StateOptions::enter() {
 }
 
 void StateOptions::clean() {
+  cleanRoomsList();
   if (StateOptions::m_sGUI != NULL) {
     delete StateOptions::m_sGUI;
     StateOptions::m_sGUI = NULL;
@@ -2814,6 +2815,30 @@ void StateOptions::createThemesList(UIList *pList) {
   }
 }
 
+// Delete the dynamically allocated room IDs that were
+// stored in pvUser as void pointers by createRoomsList.
+void StateOptions::cleanRoomsList(UIList *pList) {
+  for (unsigned int i = 0; i < pList->getEntries().size(); i++) {
+    delete reinterpret_cast<std::string *>(pList->getEntries()[i]->pvUser);
+  }
+  pList->clear();
+}
+
+// Loop through all the rooms and delete their room IDs.
+void StateOptions::cleanRoomsList() {
+  UIList *v_list;
+  std::string v_tabId;
+  for (unsigned int i = 0; i < ROOMS_NB_MAX; i++) {
+    std::ostringstream v_strRoom;
+    v_strRoom << i;
+
+    v_tabId = "MAIN:TABS:WWW_TAB:TABS:ROOMS_TAB_" + v_strRoom.str();
+    v_list =
+      reinterpret_cast<UIList *>(m_sGUI->getChild(v_tabId + ":ROOMS_LIST"));
+    cleanRoomsList(v_list);
+  }
+}
+
 void StateOptions::updateRoomsList() {
   UIList *v_list;
   std::string v_tabId;
@@ -2865,10 +2890,7 @@ void StateOptions::createRoomsList(UIList *pList) {
   }
 
   /* recreate the list */
-  for (unsigned int i = 0; i < pList->getEntries().size(); i++) {
-    delete reinterpret_cast<std::string *>(pList->getEntries()[i]->pvUser);
-  }
-  pList->clear();
+  cleanRoomsList(pList);
 
   // WR room
   v_result = xmDatabase::instance("main")->readDB(

--- a/src/states/StateOptions.h
+++ b/src/states/StateOptions.h
@@ -66,6 +66,8 @@ private:
   void updateResolutionsList();
   void updateControlsList();
   void createRoomsList(UIList *pList);
+  static void cleanRoomsList(UIList *pList);
+  static void cleanRoomsList();
   void updateRoomsList();
   void updateAudioOptions();
   void updateWWWOptions();


### PR DESCRIPTION
`createRoomsList` was allocating strings for the room IDs and storing them in `pvUser`. These strings only got freed on a subsequent call to `createRoomsList` and then replaced with new strings. There wasn't a cleanup method for the room lists so I copy-pasted parts of the existing `updateRoomsList` and `createRoomsList` methods to create cleanup methods. This could probably be done with less duplication but `StateOptions::clean` is a static method, so it can't call non-static methods.

I tried changing `updateRoomsList` to take a boolean `clear` that would make it clear the room list instead of updating it and calling that from StateOptions::clean but it wouldn't compile since static methods can't call non-static methods.
```
==3673== 192 bytes in 6 blocks are definitely lost in loss record 1,434 of 1,485
==3673==    at 0x4C2E94F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==3673==    by 0x5391B8: StateOptions::createRoomsList(UIList*) (StateOptions.cpp:2880)
==3673==    by 0x538BC1: StateOptions::updateRoomsList() (StateOptions.cpp:2830)
==3673==    by 0x5347CD: StateOptions::updateOptions() (StateOptions.cpp:2485)
==3673==    by 0x51A719: StateOptions::enter() (StateOptions.cpp:79)
==3673==    by 0x50FA8C: StateManager::pushState(GameState*) (StateManager.cpp:185)
==3673==    by 0x4FB192: StateMainMenu::checkEventsMainWindow() (StateMainMenu.cpp:399)
==3673==    by 0x4FA75F: StateMainMenu::checkEvents() (StateMainMenu.cpp:290)
==3673==    by 0x5174E5: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:123)
==3673==    by 0x4FE72D: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==3673==    by 0x512521: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:810)
==3673==    by 0x591481: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:783)
==3673==
==3673== 192 bytes in 6 blocks are definitely lost in loss record 1,435 of 1,485
==3673==    at 0x4C2E94F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==3673==    by 0x53947A: StateOptions::createRoomsList(UIList*) (StateOptions.cpp:2890)
==3673==    by 0x538BC1: StateOptions::updateRoomsList() (StateOptions.cpp:2830)
==3673==    by 0x5347CD: StateOptions::updateOptions() (StateOptions.cpp:2485)
==3673==    by 0x51A719: StateOptions::enter() (StateOptions.cpp:79)
==3673==    by 0x50FA8C: StateManager::pushState(GameState*) (StateManager.cpp:185)
==3673==    by 0x4FB192: StateMainMenu::checkEventsMainWindow() (StateMainMenu.cpp:399)
==3673==    by 0x4FA75F: StateMainMenu::checkEvents() (StateMainMenu.cpp:290)
==3673==    by 0x5174E5: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:123)
==3673==    by 0x4FE72D: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==3673==    by 0x512521: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:810)
==3673==    by 0x591481: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:783) 
```