### PR TITLE
Fix two memory leaks in xmDatabase::sync_buildServerFile

### DIFF
--- a/src/db/xmDatabase_sync.cpp
+++ b/src/db/xmDatabase_sync.cpp
@@ -111,6 +111,7 @@ void xmDatabase::sync_buildServerFile(const std::string &i_outFile,
 
   /* stats_completedLevels */
   XMFS::writeLine(pfh, "<stats_completedLevels>");
+  read_DB_free(v_result);
   v_result = readDB("SELECT dbSync, id_level, timeStamp, finishTime "
                     "FROM profile_completedLevels "
                     "WHERE sitekey=\"" +
@@ -129,6 +130,7 @@ void xmDatabase::sync_buildServerFile(const std::string &i_outFile,
              atoi(getResult(v_result, 4, i, 3)));
     XMFS::writeLine(pfh, v_line);
   }
+  read_DB_free(v_result);
   XMFS::writeLine(pfh, "</stats_completedLevels>");
 
   XMFS::writeLine(pfh, "</xmoto_sync>");


### PR DESCRIPTION
v_result wasn't getting freed after every call to `readDB`, so I added some `read_DB_free()` calls to fix the leaks.

Valgrind errors (with `valgrind --leak-check=full --show-leak-kinds=definite build/src/xmoto`):
```
==6643== 12,352 (3,344 direct, 9,008 indirect) bytes in 1 blocks are definitely lost in loss record 1,540 of 1,546
==6643==    at 0x4C308BF: realloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==6643==    by 0x706A0E8: ??? (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x704159B: ??? (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x70DBE3F: sqlite3_get_table (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x459531: xmDatabase::readDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int&) (xmDatabase.cpp:1033)
==6643==    by 0x4694B9: xmDatabase::sync_buildServerFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (xmDatabase_sync.cpp:114)
==6643==    by 0x56195C: SyncThread::realThreadFunction() (SyncThread.cpp:61)
==6643==    by 0x568932: XMThread::threadFunctionEncapsulate() (XMThread.cpp:197)
==6643==    by 0x568329: XMThread::run(void*) (XMThread.cpp:62)
==6643==    by 0x6522827: ??? (in /usr/lib64/libSDL-1.2.so.0.11.4)
==6643==    by 0x6561F08: ??? (in /usr/lib64/libSDL-1.2.so.0.11.4)
==6643==    by 0x67AD568: start_thread (in /lib64/libpthread-2.26.so)  

...

==6643== 17,584 (5,200 direct, 12,384 indirect) bytes in 1 blocks are definitely lost in loss record 1,542 of 1,546
==6643==    at 0x4C308BF: realloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==6643==    by 0x706A0E8: ??? (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x704159B: ??? (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x70DBE3F: sqlite3_get_table (in /usr/lib64/libsqlite3.so.0.8.6)
==6643==    by 0x459531: xmDatabase::readDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int&) (xmDatabase.cpp:1033)
==6643==    by 0x468FD1: xmDatabase::sync_buildServerFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (xmDatabase_sync.cpp:84)
==6643==    by 0x56195C: SyncThread::realThreadFunction() (SyncThread.cpp:61)
==6643==    by 0x568932: XMThread::threadFunctionEncapsulate() (XMThread.cpp:197)
==6643==    by 0x568329: XMThread::run(void*) (XMThread.cpp:62)
==6643==    by 0x6522827: ??? (in /usr/lib64/libSDL-1.2.so.0.11.4)
==6643==    by 0x6561F08: ??? (in /usr/lib64/libSDL-1.2.so.0.11.4)
==6643==    by 0x67AD568: start_thread (in /lib64/libpthread-2.26.so)
```