### PR TITLE
Fix tiny memory leak in TFunctor1ARef.

### DIFF
--- a/src/helpers/TFunctor.h
+++ b/src/helpers/TFunctor.h
@@ -25,6 +25,7 @@ template<class TClass>
 class TFunctor {
 public:
   virtual void call(TClass *) = 0;
+  virtual ~TFunctor() {};
 };
 
 template<class TClass, typename TArg1>


### PR DESCRIPTION
The wrong destructor was called when deleting TFunctor since it didn't
have a virtual destructor. This caused a string to leak. Since the
TFunctor1ARef destructor wasn't called, `m_argument1` (a string in the
case of `XMSession::setClientServerName`) wasn't destructed.

The leak report from Valgrind:
```
==18963== 31 bytes in 1 blocks are definitely lost in loss record 247 of 1,534
==18963==    at 0x4C2E94F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18963==    by 0x7AAE31E: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib64/libstdc++.so.6.0.25)
==18963==    by 0x7AAE648: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib64/libstdc++.so.6.0.25)
==18963==    by 0x44F946: TFunctor1ARef<XMSession, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::TFunctor1ARef(void (XMSession::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (TFunctor.h:58)
==18963==    by 0x44DACF: XMSession::setClientServerName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (XMSession.cpp:1458)
==18963==    by 0x4FC076: StateMainMenu::checkEventsNetworkTab() (StateMainMenu.cpp:510)
==18963==    by 0x4FA541: StateMainMenu::checkEvents() (StateMainMenu.cpp:297)
==18963==    by 0x517141: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:108)
==18963==    by 0x4FE4D3: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==18963==    by 0x5122C7: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:810)
==18963==    by 0x591351: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:773)
==18963==    by 0x59189C: GameApp::run_loop() (GameInit.cpp:875)
==18963==
==18963== 31 bytes in 1 blocks are definitely lost in loss record 248 of 1,534
==18963==    at 0x4C2E94F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18963==    by 0x7AAE31E: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib64/libstdc++.so.6.0.25)
==18963==    by 0x7AAE648: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /usr/lib64/libstdc++.so.6.0.25)
==18963==    by 0x44F946: TFunctor1ARef<XMSession, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::TFunctor1ARef(void (XMSession::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (TFunctor.h:58)
==18963==    by 0x44DACF: XMSession::setClientServerName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (XMSession.cpp:1458)
==18963==    by 0x45015E: TFunctor1ARef<XMSession, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::call(XMSession*) (TFunctor.h:63)
==18963==    by 0x44F70C: MultiSingleton<XMSession>::propagate(MultiSingleton<XMSession>*, TFunctor<XMSession>*) (MultiSingleton.h:169)
==18963==    by 0x44DADE: XMSession::setClientServerName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (XMSession.cpp:1458)
==18963==    by 0x4FC076: StateMainMenu::checkEventsNetworkTab() (StateMainMenu.cpp:510)
==18963==    by 0x4FA541: StateMainMenu::checkEvents() (StateMainMenu.cpp:297)
==18963==    by 0x517141: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:108)
==18963==    by 0x4FE4D3: StateMainMenu::xmKey(InputEventType, XMKey const&) (StateMainMenu.cpp:801)
==18963==       
```