### PR TITLE
Fix window icon memory leak.

### DIFF
--- a/src/xmoto/Game.cpp
+++ b/src/xmoto/Game.cpp
@@ -135,6 +135,7 @@ void GameApp::_InitWin(bool bInitGraphics) {
     SDL_SetColorKey(
       v_icon, SDL_SRCCOLORKEY, SDL_MapRGB(v_icon->format, 236, 45, 211));
     SDL_WM_SetIcon(v_icon, NULL);
+    m_icon = v_icon;
   }
 #endif
 
@@ -156,6 +157,9 @@ GameApp::~GameApp() {
   StateManager::cleanStates();
   delete m_userConfig;
   //  delete m_fileGhost;
+  if (m_icon != NULL) {
+    SDL_FreeSurface(m_icon);
+  }
 }
 
 GameApp::GameApp() {
@@ -201,6 +205,7 @@ GameApp::GameApp() {
 
   m_xmdemo = NULL;
   m_loadLevelHook_per = 0;
+  m_icon = NULL;
 }
 
 /*===========================================================================

--- a/src/xmoto/Game.h
+++ b/src/xmoto/Game.h
@@ -289,6 +289,9 @@ private:
   bool m_hasKeyboardFocus;
   bool m_isIconified;
 
+  // Window icon
+  SDL_Surface *m_icon;
+
   // demo
   XMDemo *m_xmdemo;
 };


### PR DESCRIPTION
The window icon was loaded in GameApp::_initWin but never freed. The documentation on [SDL_LoadBMP](https://wiki.libsdl.org/SDL_LoadBMP) says the new surface should be freed with `SDL_FreeSurface`. I added a call to SDL_FreeSurface in the GameApp destructor to free the new `m_icon` variable that is set to the window icon `v_icon` in _initWin. `m_icon` is initialized to NULL in GameApp constructor.

Valgrind error:
```
==20034== 4,324 (88 direct, 4,236 indirect) bytes in 1 blocks are definitely lost in loss record 1,519 of 1,531
==20034==    at 0x4C2E2DF: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==20034==    by 0x676BD2B: SDL_CreateRGBSurface (in /usr/lib64/libSDL-1.2.so.0.11.4)
==20034==    by 0x6766EDE: SDL_LoadBMP_RW (in /usr/lib64/libSDL-1.2.so.0.11.4)
==20034==    by 0x57E9A2: GameApp::_InitWin(bool) (Game.cpp:132)
==20034==    by 0x58E893: GameApp::run_load(int, char**) (GameInit.cpp:348)
==20034==    by 0x58D698: GameApp::run(int, char**) (GameInit.cpp:158)
==20034==    by 0x58D4BC: main (GameInit.cpp:117)      
```