### PR TITLE
SDL2: Fix window icon leak.

### DIFF
--- a/src/drawlib/DrawLibOpenGL.cpp
+++ b/src/drawlib/DrawLibOpenGL.cpp
@@ -372,6 +372,7 @@ void DrawLibOpenGL::init(unsigned int nDispWidth,
     SDL_SetColorKey(
       v_icon, SDL_TRUE, SDL_MapRGB(v_icon->format, 236, 45, 211));
     SDL_SetWindowIcon(m_window, v_icon);
+    SDL_FreeSurface(v_icon);
   }
 #endif
 


### PR DESCRIPTION
This fixes a small memory leak in `DrawLibOpenGL::init`  by freeing the icon surface immediately after attaching it to the window like the code example at [SDL Wiki](https://wiki.libsdl.org/SDL_SetWindowIcon) shows.

Valgrind leak report:
```
==13022== 3,672 (96 direct, 3,576 indirect) bytes in 1 blocks are definitely lost in loss record 4,743 of 4,847
==13022==    at 0x4C306B5: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==13022==    by 0x657EE90: SDL_calloc_REAL (in /usr/lib64/libSDL2-2.0.so.0.10.0)
==13022==    by 0x65B54D0: SDL_CreateRGBSurfaceWithFormat_REAL (in /usr/lib64/libSDL2-2.0.so.0.10.0)
==13022==    by 0x65AD8C0: SDL_LoadBMP_RW_REAL (in /usr/lib64/libSDL2-2.0.so.0.10.0)
==13022==    by 0x478C7F: DrawLibOpenGL::init(unsigned int, unsigned int, unsigned int, bool) (DrawLibOpenGL.cpp:368)
==13022==    by 0x593852: GameApp::run_load(int, char**) (GameInit.cpp:374)
==13022==    by 0x592452: GameApp::run(int, char**) (GameInit.cpp:160)
==13022==    by 0x592276: main (GameInit.cpp:119)
```