### PR TITLE
Nix: In-tree Nixpkgs derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ CTestTestfile.cmake
 ## Custom
 
 /[Bb]uild*/
+
+## Nix
+
+/result*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+import ./nix

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,8 @@
+{ ... } @ commonArgs: let
+  pkgs = commonArgs.pkgs or import <nixpkgs> { };
+  commonArgsPruned = builtins.removeAttrs commonArgs [
+    "pkgs"
+  ];
+common = {
+  xmoto = pkgs.callPackage ./xmoto.nix commonArgsPruned;
+}; in common

--- a/nix/xmoto.nix
+++ b/nix/xmoto.nix
@@ -1,0 +1,119 @@
+{ lib, stdenv, buildPackages, fetchurl, nix-gitignore
+, curl, libjpeg, libpng, libxml2, sqlite, zlib
+, enableCmakeNinja ? false
+, enableDev ? false
+, enableGettext ? false
+, enableOpengl ? true, libGL ? null #, libGLU ? null
+, enableSdl ? false, SDL ? null, SDL_gfx ? null, SDL_mixer ? null, SDL_net ? null, SDL_ttf ? null
+, enableSystemBzip2 ? false, bzip2 ? null
+, enableSystemLua ? false, lua ? null
+, enableSystemOde ? false, ode ? null
+, enableSystemXdg ? false, libxdg_basedir ? null
+}:
+
+assert enableCmakeNinja -> buildPackages.ninja != null;
+
+assert enableGettext -> buildPackages.gettext != null;
+assert enableGettext -> buildPackages.libintl != null;
+
+# Can't disable OpenGL yet.
+assert libGL != null;
+
+assert enableOpengl -> libGL != null;
+
+# Can't disable SDL yet.
+assert SDL != null;
+assert SDL_mixer != null;
+assert SDL_net != null;
+assert SDL_ttf != null;
+
+assert enableSdl -> SDL != null;
+assert enableSdl -> SDL_gfx != null;
+assert enableSdl -> SDL_mixer != null;
+assert enableSdl -> SDL_net != null;
+assert enableSdl -> SDL_ttf != null;
+
+assert enableSystemBzip2 -> bzip2 != null;
+assert enableSystemLua -> lua != null;
+assert enableSystemOde -> ode != null;
+assert enableSystemXdg -> libxdg_basedir != null;
+
+let
+  inherit (lib) optionals;
+  cmakeCacheEntry = var: value: "-D${var}=${value}";
+  cmakeCacheTypedEntry = var: type: value: "-D${var}:${type}=${value}";
+  cmakeOption = var: value:
+    cmakeCacheTypedEntry var "BOOL" (if value then "ON" else "OFF");
+in
+stdenv.mkDerivation rec {
+  pname = "xmoto";
+  version = "0.6.1-head";
+
+  src = nix-gitignore.gitignoreSource [ "/nix" ] ../.;
+
+  nativeBuildInputs = [
+    buildPackages.cmake
+  ] ++ optionals enableCmakeNinja [
+    buildPackages.ninja
+  ] ++ optionals enableGettext [
+    buildPackages.gettext
+    buildPackages.libintl
+  ];
+
+  buildInputs = [
+    curl
+    libjpeg
+    libpng
+    libxml2
+    sqlite
+    zlib
+  ] ++ [
+    libGL
+  ] ++ optionals enableOpengl [
+    # libGL
+  ] ++ [
+    SDL
+    SDL_mixer
+    SDL_net
+    SDL_ttf
+  ] ++ optionals enableSdl [
+    # SDL
+    SDL_gfx
+    # SDL_mixer
+    # SDL_net
+    # SDL_ttf
+  ] ++ optionals enableSystemBzip2 [
+    bzip2
+  ] ++ optionals enableSystemLua [
+    lua
+  ] ++ optionals enableSystemOde [
+    ode
+  ] ++ optionals enableSystemXdg [
+    libxdg_basedir
+  ];
+
+  cmakeFlags = [
+    (cmakeOption "ALLOW_DEV" enableDev)
+    (cmakeOption "USE_GETTEXT" enableGettext)
+    (cmakeOption "USE_OPENGL" enableOpengl)
+    (cmakeOption "USE_SDLGFX" enableSdl)
+    (cmakeOption "PREFER_SYSTEM_BZip2" enableSystemBzip2)
+    (cmakeOption "PREFER_SYSTEM_Lua" enableSystemLua)
+    (cmakeOption "PREFER_SYSTEM_ODE" enableSystemOde)
+    (cmakeOption "PREFER_SYSTEM_XDG" enableSystemXdg)
+  ];
+
+  meta = with lib; {
+    description =
+      "A challenging 2D motocross platform game, where physics play an important role";
+    longDescription = ''
+      X-Moto is a challenging 2D motocross platform game, where physics plays an all important role in the gameplay.
+      You need to control your bike to its limits, if you want to have a chance to finish the most difficult challenges.
+    '';
+    homepage = "https://xmoto.tuxfamily.org";
+    maintainers = with maintainers; [ bb010g raskin pSub ];
+    platforms = platforms.all;
+    license = licenses.gpl2Plus;
+  };
+}
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -402,6 +402,10 @@ target_include_directories(xmoto
 
   "${PROJECT_SOURCE_DIR}/src"
   "${LIBXML2_INCLUDE_DIR}"
+  "${SDL_INCLUDE_DIR}"
+  "${SDL_MIXER_INCLUDE_DIRS}"
+  "${SDL_NET_INCLUDE_DIRS}"
+  "${SDL_TTF_INCLUDE_DIRS}"
   "$<${USE_SYSTEM_Lua}:${LUA_INCLUDE_DIR}>"
   "$<$<NOT:${USE_SYSTEM_Lua}>:${PROJECT_SOURCE_DIR}/vendor/lua/lua>"
 )
@@ -436,9 +440,9 @@ target_link_libraries(xmoto PUBLIC
   ${OPENGL_LIBRARIES}
   ${PNG_LIBRARY}
   ${SDL_LIBRARY}
-  ${SDLMIXER_LIBRARY}
-  ${SDLNET_LIBRARY}
-  ${SDLTTF_LIBRARY}
+  ${SDL_MIXER_LIBRARIES}
+  ${SDL_NET_LIBRARIES}
+  ${SDL_TTF_LIBRARIES}
   ${SQLITE3_LIBRARIES}
   $<${USE_SYSTEM_XDG}:${XDG_LIBRARY}>
   $<$<NOT:${USE_SYSTEM_XDG}>:xdgbasedir>
@@ -655,9 +659,9 @@ message("Ode       libraries: ${ODE_LIBRARY}")
 message("OpenGL    libraries: ${OPENGL_LIBRARIES}")
 message("Png       libraries: ${PNG_LIBRARY}")
 message("SDL       libraries: ${SDL_LIBRARY}")
-message("SDL_mixer libraries: ${SDLMIXER_LIBRARY}")
-message("SDL_net   libraries: ${SDLNET_LIBRARY}")
-message("SDL_ttf   libraries: ${SDLTTF_LIBRARY}")
+message("SDL_mixer libraries: ${SDL_MIXER_LIBRARIES}")
+message("SDL_net   libraries: ${SDL_NET_LIBRARIES}")
+message("SDL_ttf   libraries: ${SDL_TTF_LIBRARIES}")
 message("Sqlite3   libraries: ${SQLITE3_LIBRARIES}")
 message("Xdg       libraries: ${XDG_LIBRARY}")
 message("Zlib      libraries: ${ZLIB_LIBRARIES}")


### PR DESCRIPTION
    nix build -L --show-trace \
      '((import ./. { enableCmakeNinja = true; }).xmoto)'

This makes it way easier for me (on NixOS) to test out our build system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xmoto/xmoto/105)
<!-- Reviewable:end -->
