### PR TITLE
Fix a few memory leaks found by Cppcheck.

### DIFF
--- a/src/helpers/System.cpp
+++ b/src/helpers/System.cpp
@@ -46,6 +46,7 @@ std::vector<std::string> *System::getDisplayModes(int windowed) {
   /* Check is there are any modes available */
   if (sdl_modes == (SDL_Rect **)0) {
     LogWarning("No display modes available.");
+    delete modes;
     throw Exception("getDisplayModes : No modes available.");
   }
 

--- a/src/xmoto/Replay.cpp
+++ b/src/xmoto/Replay.cpp
@@ -1024,6 +1024,7 @@ ReplayInfo *Replay::getReplayInfos(const std::string p_ReplayName) {
 
   if (XMFS::readInt_LE(pfh) != 0x12345678) {
     XMFS::closeFile(pfh);
+    delete pRpl;
     return NULL;
   }
 

--- a/src/xmoto/Sound.cpp
+++ b/src/xmoto/Sound.cpp
@@ -172,6 +172,7 @@ SoundSample *Sound::loadSample(const std::string &File) {
   FileHandle *pf = XMFS::openIFile(FDT_DATA, File);
   if (pf == NULL) {
     SDL_FreeRW(pOps);
+    delete pSample;
     throw Exception("failed to open sample file " + File);
   }
 


### PR DESCRIPTION
In System.cpp, when `SDL_ListModes` fails, an exception is thrown without deleting `modes` first. In Replay.cpp, when the magic number check fails, `pRpl` isn't deleted. In Sound.cpp, when opening a file fails, `pSample` is leaked because an exception is thrown and the sample isn't deleted before the pointer to it goes away.

Here's the errors from Cppcheck:
```
[src\helpers\System.cpp:49]: (error) Memory leak: modes
[src\xmoto\Replay.cpp:1027]: (error) Memory leak: pRpl
[src\xmoto\Sound.cpp:175]: (error) Memory leak: pSample
```