### PR TITLE
Fix crash in _findnext on Windows 10.

### DIFF
--- a/src/common/VFileIO.cpp
+++ b/src/common/VFileIO.cpp
@@ -255,7 +255,7 @@ void XMFS::_FindFilesRecursive(const std::string &DirX,
                                std::vector<std::string> &List) {
 /* Windows? */
 #ifdef WIN32
-  long fh;
+  intptr_t fh;
   struct _finddata_t fd;
 
   std::string Dir = DirX;
@@ -350,7 +350,7 @@ std::vector<std::string> XMFS::findPhysFiles(FileDataType i_fdt,
     if (bRecurse) {
       _FindFilesRecursive(UDirToSearch, Wildcard, Result);
     } else {
-      long fh;
+      intptr_t fh;
       struct _finddata_t fd;
 
       if ((fh = _findfirst((UDirToSearch + Wildcard).c_str(), &fd)) != -1L) {
@@ -368,7 +368,7 @@ std::vector<std::string> XMFS::findPhysFiles(FileDataType i_fdt,
     if (bRecurse) {
       _FindFilesRecursive(DataDirToSearch, Wildcard, Result);
     } else {
-      long fh;
+      intptr_t fh;
       struct _finddata_t fd;
 
       if ((fh = _findfirst((DataDirToSearch + Wildcard).c_str(), &fd)) != -1L) {


### PR DESCRIPTION
`_findnext` takes, and `_findfirst` returns, an `intptr_t` for the file handle, not `long`. Using an incorrect type for the file handle was causing crashes.

Fixes #125.

Compiled for Windows 10 using MSYS2 MinGW64 shell, /mingw64/bin/cmake, "MSYS2 Makefiles" generator.

[Docs for _findfirst](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/findfirst-functions?view=msvc-160).
[Docs for _findnext](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/findnext-functions?view=msvc-160).