### PR TITLE
Hotfix for 0.6.2

### DIFF
--- a/src/db/xmDatabase.cpp
+++ b/src/db/xmDatabase.cpp
@@ -150,21 +150,23 @@ bool xmDatabase::init(const std::string &i_dbFileUTF8,
   }
 
   if (m_openingVersion < XMDB_VERSION) {
-    LogInfo("Backing up XmDb");
+    if (m_openingVersion != 0) {
+      LogInfo("Backing up XmDb");
 
-    try {
-      backupXmDb(i_dbFileUTF8);
-    } catch (Exception &e) {
-      LogError("Failed to backup database:");
-      LogError(e.getMsg().c_str());
-      LogError("Bailing out..");
+      try {
+        backupXmDb(i_dbFileUTF8);
+      } catch (Exception &e) {
+        LogError("Failed to backup database:");
+        LogError(e.getMsg().c_str());
+        LogError("Bailing out..");
 
-      if (m_db != NULL) {
-        sqlite3_close(m_db);
-        m_db = NULL;
+        if (m_db != NULL) {
+          sqlite3_close(m_db);
+          m_db = NULL;
+        }
+
+        return false;
       }
-
-      return false;
     }
 
     LogInfo(

--- a/src/db/xmDatabase.cpp
+++ b/src/db/xmDatabase.cpp
@@ -96,7 +96,7 @@ void xmDatabase::preInitForProfileLoading(const std::string &i_dbFileUTF8) {
 
 void xmDatabase::backupXmDb(const std::string &dbFile) {
   std::ostringstream backupName;
-  backupName << "xm.v" << m_openingVersion << "." << iso8601Date() << ".db";
+  backupName << "xm.v" << m_openingVersion << "." << currentDateTime() << ".db";
 
   std::string outputPath;
   if (!XMFS::copyFile(FDT_DATA,

--- a/src/helpers/Time.cpp
+++ b/src/helpers/Time.cpp
@@ -7,3 +7,10 @@ std::string iso8601Date() {
   std::strftime(datetime, sizeof(datetime), "%Y-%m-%dT%H:%M:%SZ", std::localtime(&t));
   return std::string(datetime);
 }
+
+std::string currentDateTime() {
+  std::time_t t = std::time(nullptr);
+  char datetime[sizeof("1970-01-01_00-00-00")];
+  std::strftime(datetime, sizeof(datetime), "%Y-%m-%d_%H-%M-%S", std::localtime(&t));
+  return std::string(datetime);
+}

--- a/src/helpers/Time.h
+++ b/src/helpers/Time.h
@@ -5,4 +5,7 @@
 
 std::string iso8601Date();
 
+// Safe for use in file paths
+std::string currentDateTime();
+
 #endif // __XMOTO_TIME_H__

--- a/src/xmoto/GameInit.cpp
+++ b/src/xmoto/GameInit.cpp
@@ -128,7 +128,7 @@ int main(int nNumArgs, char **ppcArgs) {
     snprintf(cBuf,
              1024,
              "Fatal exception occurred: %s\n"
-             "Consult the logs/latest.log file for more information about what\n"
+             "Consult the logs/xmoto.log file for more information about what\n"
              "might has occurred.\n",
              e.getMsg().c_str());
     MessageBox(NULL, cBuf, "X-Moto Error", MB_OK | MB_ICONERROR);


### PR DESCRIPTION
Windows doesn't like `:`s in file names, which caused the game to crash on startup when a database backup is done