### PR TITLE
CMake: Set endianness flag during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ ${APP_VERSION_PATCH}")
 include(CheckCXXCompilerFlag)
 include(CheckPrototypeDefinition)
 include(CheckSymbolExists)
+include(TestBigEndian)
 
 include(CMake/mxe.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -528,6 +528,9 @@ target_compile_definitions(xmoto PUBLIC USE_GETTEXT=$<BOOL:${USE_GETTEXT}>)
 target_compile_definitions(xmoto PUBLIC ALLOW_DEV=$<BOOL:${ALLOW_DEV}>)
 target_compile_definitions(xmoto PUBLIC BUILD_MACOS_BUNDLE=$<BOOL:${BUILD_MACOS_BUNDLE}>)
 
+test_big_endian(XMOTO_BIG_ENDIAN)
+target_compile_definitions(xmoto PUBLIC XMOTO_BIG_ENDIAN=${XMOTO_BIG_ENDIAN})
+
 target_compile_definitions(xmoto PUBLIC $<$<BOOL:${STATIC_BUILD}>:CURL_STATICLIB>)
 target_compile_definitions(xmoto PUBLIC $<$<BOOL:${STATIC_BUILD}>:LIBXML_STATIC>)
 

--- a/src/common/BuildConfig.h
+++ b/src/common/BuildConfig.h
@@ -56,4 +56,8 @@ Build configuration
 #define USE_GETTEXT 1
 #endif
 
+#ifndef XMOTO_BIG_ENDIAN
+#define XMOTO_BIG_ENDIAN 0
+#endif
+
 #endif

--- a/src/common/DBuffer.cpp
+++ b/src/common/DBuffer.cpp
@@ -92,7 +92,7 @@ template void DBuffer::writeBuf(const char *, int);
 template void DBuffer::writeBuf(char *, int);
 
 void DBuffer::writeBuf_LE(const char *pcBuf, int nBufSize) {
-  if (SwapEndian::bigendien) {
+  if (SwapEndian::bigendian) {
     writeBuf(std::reverse_iterator<const char *>(pcBuf + nBufSize), nBufSize);
   } else {
     writeBuf(pcBuf, nBufSize);

--- a/src/common/VCommon.h
+++ b/src/common/VCommon.h
@@ -31,25 +31,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* Some places #define _T, which we want for a template parameter */
 #undef _T
 
-#ifdef HAVE_LIBKERN_OSBYTEORDER_H
-/* Configure's endian test is no good for universal binaries, instead
- * use the OS X header. */
-#undef XMOTO_LITTLE_ENDIAN
-#undef XMOTO_BIG_ENDIAN
-#include <libkern/OSByteOrder.h>
-#ifdef __BIG_ENDIAN__
-#define XMOTO_BIG_ENDIAN 1
-#else
-#define XMOTO_LITTLE_ENDIAN 1
-#endif
-#else
-/* Use the configure endian test */
-#if !defined(XMOTO_LITTLE_ENDIAN) && !defined(XMOTO_BIG_ENDIAN)
-/* Assume little endian */
-#define XMOTO_LITTLE_ENDIAN 1
-#endif
-#endif
-
 // used a comparator in sdt::map
 #include <string.h> // for strcmp
 struct ltstr {

--- a/src/helpers/SwapEndian.cpp
+++ b/src/helpers/SwapEndian.cpp
@@ -82,7 +82,7 @@ static void SerializedBikeStateNoSwap(SerializedBikeState &sbs) {
   ================
 */
 
-bool SwapEndian::bigendien = false;
+bool SwapEndian::bigendian = false;
 short (*SwapEndian::_BigShort)(short s) = NULL;
 short (*SwapEndian::_LittleShort)(short s) = NULL;
 int (*SwapEndian::_BigLong)(int l) = NULL;
@@ -99,7 +99,7 @@ void SwapEndian::Swap_Init() {
 
   // set the byte swapping variables in a portable manner
   if (*(short *)swaptest == 1) {
-    bigendien = false;
+    bigendian = false;
     _BigShort = ShortSwap;
     _LittleShort = ShortNoSwap;
     _BigLong = LongSwap;
@@ -111,7 +111,7 @@ void SwapEndian::Swap_Init() {
     _BigSerializedBikeState = SerializedBikeStateSwap;
     _LittleSerializedBikeState = SerializedBikeStateNoSwap;
   } else {
-    bigendien = true;
+    bigendian = true;
     _BigShort = ShortNoSwap;
     _LittleShort = ShortSwap;
     _BigLong = LongNoSwap;

--- a/src/helpers/SwapEndian.h
+++ b/src/helpers/SwapEndian.h
@@ -1,13 +1,13 @@
 #ifndef __SWAPENDIAN_H__
 #define __SWAPENDIAN_H__
 
-#include "common/VCommon.h" // For XMOTO_LITTLE_ENDIAN
+#include "common/BuildConfig.h" // For XMOTO_BIG_ENDIAN
 #include "xmscene/Scene.h" // For SerializedBikeState
 #include <iterator>
 
 class SwapEndian {
 public:
-  static bool bigendien;
+  static bool bigendian;
 
   static void Swap_Init();
 
@@ -30,7 +30,7 @@ public:
     _LittleSerializedBikeState(sbs);
   }
 
-#ifdef XMOTO_LITTLE_ENDIAN
+#if !XMOTO_BIG_ENDIAN
   template<typename _T>
   static _T LittleIter(_T p, int) {
     return p;

--- a/src/xmoto/GameInit.cpp
+++ b/src/xmoto/GameInit.cpp
@@ -260,7 +260,7 @@ void GameApp::run_load(int nNumArgs, char **ppcArgs) {
 
   LogInfo(std::string("X-Moto " + XMBuild::getVersionString(true)).c_str());
   LogInfo("Started at %s", iso8601Date().c_str());
-  auto endianness = SwapEndian::bigendien ? "big" : "little";
+  auto endianness = SwapEndian::bigendian ? "big" : "little";
   LogInfo("System is %s-endian", endianness);
 
   LogInfo("User data   directory: %s", XMFS::getUserDir(FDT_DATA).c_str());


### PR DESCRIPTION
Allows target system's endianness to be determined automatically, the same way it was done with Autotools

Fixes #173