### PR TITLE
xmDatabase: Always allow double-quoted strings

### DIFF
--- a/src/db/xmDatabase.cpp
+++ b/src/db/xmDatabase.cpp
@@ -58,6 +58,10 @@ void xmDatabase::openIfNot(const std::string &i_dbFileUTF8) {
                     ") : " + sqlite3_errmsg(m_db));
   }
 
+#ifdef SQLITE_DBCONFIG_DQS_DML
+  sqlite3_db_config(m_db, SQLITE_DBCONFIG_DQS_DML, 1, NULL);
+#endif
+
   sqlite3_busy_timeout(m_db, DB_BUSY_TIMEOUT);
   sqlite3_trace(m_db, sqlTrace, NULL);
   createUserFunctions();


### PR DESCRIPTION
SQLite can allow double-quoted strings as an extension/quirk, but this can be disabled. Since X-Moto always uses double-quoted strings, configure the database to always allow this.

This will do nothing if DQS is already enabled, or if the current version of SQLite doesn't know about the DQS knob, so it should always be safe.

See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for the description of this configuration parameter.
See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=278669 for a description of a system where this causes xmoto to crash