### PR TITLE
Fixes for NixOS

### DIFF
--- a/nix/xmoto.nix
+++ b/nix/xmoto.nix
@@ -3,8 +3,8 @@
 , enableCmakeNinja ? false
 , enableDev ? false
 , enableGettext ? false
-, enableOpengl ? true, libGL ? null #, libGLU ? null
-, enableSdl ? false, SDL ? null, SDL_gfx ? null, SDL_mixer ? null, SDL_net ? null, SDL_ttf ? null
+, enableOpengl ? true, libGL ? null, libGLU ? null
+, enableSdl ? false, SDL2 ? null, SDL2_gfx ? null, SDL2_mixer ? null, SDL2_net ? null, SDL2_ttf ? null
 , enableSystemBzip2 ? false, bzip2 ? null
 , enableSystemLua ? false, lua ? null
 , enableSystemOde ? false, ode ? null
@@ -22,16 +22,16 @@ assert libGL != null;
 assert enableOpengl -> libGL != null;
 
 # Can't disable SDL yet.
-assert SDL != null;
-assert SDL_mixer != null;
-assert SDL_net != null;
-assert SDL_ttf != null;
+assert SDL2 != null;
+assert SDL2_mixer != null;
+assert SDL2_net != null;
+assert SDL2_ttf != null;
 
-assert enableSdl -> SDL != null;
-assert enableSdl -> SDL_gfx != null;
-assert enableSdl -> SDL_mixer != null;
-assert enableSdl -> SDL_net != null;
-assert enableSdl -> SDL_ttf != null;
+assert enableSdl -> SDL2 != null;
+assert enableSdl -> SDL2_gfx != null;
+assert enableSdl -> SDL2_mixer != null;
+assert enableSdl -> SDL2_net != null;
+assert enableSdl -> SDL2_ttf != null;
 
 assert enableSystemBzip2 -> bzip2 != null;
 assert enableSystemLua -> lua != null;
@@ -69,16 +69,17 @@ stdenv.mkDerivation rec {
     zlib
   ] ++ [
     libGL
+    libGLU
   ] ++ optionals enableOpengl [
     # libGL
   ] ++ [
-    SDL
-    SDL_mixer
-    SDL_net
-    SDL_ttf
+    SDL2
+    SDL2_mixer
+    SDL2_net
+    SDL2_ttf
   ] ++ optionals enableSdl [
     # SDL
-    SDL_gfx
+    SDL2_gfx
     # SDL_mixer
     # SDL_net
     # SDL_ttf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,8 @@ endif()
 if(ON OR USE_SDLGFX)
   # This is a workaround required on some systems that ship a broken sdl2-config.cmake
   find_library(SDL2_LIBRARIES NAMES SDL2 SDL2main)
-  if(NOT SDL2_LIBRARIES)
+  if(NOT SDL2_LIBRARIES OR DEFINED ENV{NIX_STORE})
+    # NixOS include dirs are not in the usual places compared to other distros.
     find_package(SDL2 REQUIRED)
 
     if("${SDL2_LIBRARIES}" STREQUAL "")


### PR DESCRIPTION
This fixes compile on NixOS using `nix-build`. The `xmoto.nix` file was pulling in SDL1 instead of SDL2, which caused errors about SDL.h missing when compiling. Also, glu.h was "missing", but only because xmoto.nix didn't declare that the game uses libGLU. The second commit correctly finds the location of the missing _xmoto.bin_ file which is in the _share/xmoto_ folder next to the _bin_ once it is installed into _/nix/store_.