### PR TITLE
Fix minor 4KiB createEntity and cpPinJointNew memory leak

### DIFF
--- a/src/xmscene/Entity.cpp
+++ b/src/xmscene/Entity.cpp
@@ -644,18 +644,22 @@ void Joint::loadToPlay(Level *i_level, ChipmunkWorld *i_chipmunkWorld) {
   if (group2 != 1)
     getEndBlock()->getPhysicShape()->group = group;
 
+  m_associatedSpace = i_chipmunkWorld->getSpace();
   switch (getJointType()) {
     case Pivot:
       cpVect v;
       v.x = DynamicPosition().x * CHIP_SCALE_RATIO;
       v.y = DynamicPosition().y * CHIP_SCALE_RATIO;
 
-      cpSpaceAddJoint(i_chipmunkWorld->getSpace(),
-                      cpPivotJointNew(body1, body2, v));
+      m_joint = cpPivotJointNew(body1, body2, v);
+      cpSpaceAddJoint(m_associatedSpace,
+                      m_joint);
       break;
     case Pin:
-      cpSpaceAddJoint(i_chipmunkWorld->getSpace(),
-                      cpPinJointNew(body1, body2, cpvzero, cpvzero));
+
+      m_joint = cpPinJointNew(body1, body2, cpvzero, cpvzero);
+      cpSpaceAddJoint(m_associatedSpace,
+                      m_joint);
       break;
     case JointNone:
     default:
@@ -664,6 +668,11 @@ void Joint::loadToPlay(Level *i_level, ChipmunkWorld *i_chipmunkWorld) {
 }
 
 void Joint::unloadToPlay() {
+  if (m_associatedSpace && m_joint) {
+    cpSpaceRemoveJoint(m_associatedSpace, m_joint);
+    cpJointFree(m_joint);
+    m_joint = nullptr;
+  }
   // is cpSpaceRemoveJoint needed ?
 }
 

--- a/src/xmscene/Entity.h
+++ b/src/xmscene/Entity.h
@@ -177,6 +177,8 @@ private:
 
 typedef enum jointType { JointNone, Pivot, Pin } jointType;
 
+class cpSpace;
+class cpJoint;
 class Joint : public Entity {
 public:
   Joint(const std::string &i_id)
@@ -215,6 +217,8 @@ private:
 
   Block *m_startBlock;
   Block *m_endBlock;
+  cpSpace *m_associatedSpace = nullptr; // not an owning pointer
+  cpJoint *m_joint = nullptr; // underlying Chipmunk joint
 
   static unsigned int getCurrentCollisionGroup();
   static void setNextCollisionGroup();

--- a/src/xmscene/Level.cpp
+++ b/src/xmscene/Level.cpp
@@ -1468,6 +1468,12 @@ void Level::unloadLevelBody() {
   }
   m_entities.clear();
 
+  /* joints */
+  for (unsigned int i = 0; i < m_joints.size(); i++) {
+    delete m_joints[i];
+  }
+  m_joints.clear();
+
   m_numberLayer = 0;
   m_layerOffsets.clear();
   m_isLayerFront.clear();


### PR DESCRIPTION
Entity::createEntity is returning a new Joint, Checkpoint, or Entity which is being leaked by one of the enclosing functions. Level::importBinary (Level.cpp:1182) is adding the returned Entity as a Joint to m_joints. Later, in Level::unloadToPlay calls unloadToPlay on each Joint in m_joints. Level::unloadToPlay is called by ~Level, Scene::endLevel, and Level::unloadLevelBody.

Need to free Chipmunk joint when deleting instances of Joint class. Added code to Joint::unloadToPlay to remove the joint from the chipmunk space and then free it, since the corresponding loadToPlay creates a joint and adds it to a space.

Note: this probably doesn't apply if the chipmunk 7 PR gets merged first,.

Leaks found with Valgrind running in openSUSE on Windows Subsystem for Linux version 1 on Windows 10

XMoto 0.6.2 memory leak(?) 2025-03-22

XMoto Commit: v0.6.2-51-gf55b9ee4
Valgrind: 3.22.0
Distro: openSUSE 15.6
WSL: 1
Valgrind command-line: ~/src/xmoto/build> valgrind --leak-check=full --undef-value-errors=no --num-callers=50 --log-file=xmoto-%p.valgrind src/xmoto

<details>

<summary> Valgrind logs </summary>

Entity::createEntity (2.7 KiB leaked)
```valgrind
==19140== 
==19140== 2,720 bytes in 10 blocks are definitely lost in loss record 5,175 of 5,911
==19140==    at 0x4841EBF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19140==    by 0x63EEA3: Entity::createEntity(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, EntitySpeciality, Vector2<float> const&, float, bool, float, float, float, float, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (Entity.cpp:297)
==19140==    by 0x640A19: Entity::readFromBinary(FileHandle*) (Entity.cpp:496)
==19140==    by 0x64E0B8: Level::importBinary(FileDataType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (Level.cpp:1182)
==19140==    by 0x64CA2F: Level::loadFullyFromFile(bool) (Level.cpp:905)
==19140==    by 0x657687: Scene::prePlayLevel(DBuffer*, bool, bool, bool) (Scene.cpp:562)
==19140==    by 0x55A6E6: StatePreplayingGame::preloadLevels() (StatePreplayingGame.cpp:51)
==19140==    by 0x5570FA: StatePreplaying::enter() (StatePreplaying.cpp:142)
==19140==    by 0x521080: StateManager::pushState(GameState*) (StateManager.cpp:189)
==19140==    by 0x505103: StateLevelPackViewer::checkEvents() (StateLevelPackViewer.cpp:126)
==19140==    by 0x5291E2: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:125)
==19140==    by 0x505BF4: StateLevelPackViewer::xmKey(InputEventType, XMKey const&) (StateLevelPackViewer.cpp:214)
==19140==    by 0x523C48: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:813)
==19140==    by 0x5A71C6: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:774)
==19140==    by 0x5A781D: GameApp::run_loop() (GameInit.cpp:925)
==19140==    by 0x5A3888: GameApp::run(int, char**) (GameInit.cpp:158)
==19140==    by 0x5A36A2: main (GameInit.cpp:116)
==19140== 
```

cpPinJointNew (1.8 KiB leaked)
```
==27475== 
==27475== 960 bytes in 10 blocks are definitely lost in loss record 4,923 of 6,009
==27475==    at 0x4841744: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27475==    by 0x66E11D: cpPinJointAlloc (cpJoint.c:116)
==27475==    by 0x66E267: cpPinJointNew (cpJoint.c:143)
==27475==    by 0x6416BC: Joint::loadToPlay(Level*, ChipmunkWorld*) (Entity.cpp:657)
==27475==    by 0x64EB18: Level::loadToPlay(ChipmunkWorld*, PhysicsSettings*, bool) (Level.cpp:1329)
==27475==    by 0x6591B7: Scene::_GenerateLevel(bool) (Scene.cpp:883)
==27475==    by 0x657D0C: Scene::prePlayLevel(DBuffer*, bool, bool, bool) (Scene.cpp:640)
==27475==    by 0x55A6E6: StatePreplayingGame::preloadLevels() (StatePreplayingGame.cpp:51)
==27475==    by 0x5570FA: StatePreplaying::enter() (StatePreplaying.cpp:142)
==27475==    by 0x521080: StateManager::pushState(GameState*) (StateManager.cpp:189)
==27475==    by 0x505103: StateLevelPackViewer::checkEvents() (StateLevelPackViewer.cpp:126)
==27475==    by 0x5291E2: StateMenu::xmKey(InputEventType, XMKey const&) (StateMenu.cpp:125)
==27475==    by 0x505BF4: StateLevelPackViewer::xmKey(InputEventType, XMKey const&) (StateLevelPackViewer.cpp:214)
==27475==    by 0x523C48: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:813)
==27475==    by 0x5A71C6: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:774)
==27475==    by 0x5A781D: GameApp::run_loop() (GameInit.cpp:925)
==27475==    by 0x5A3888: GameApp::run(int, char**) (GameInit.cpp:158)
==27475==    by 0x5A36A2: main (GameInit.cpp:116)
==27475== 
==27475== 960 bytes in 10 blocks are definitely lost in loss record 4,924 of 6,009
==27475==    at 0x4841744: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27475==    by 0x66E11D: cpPinJointAlloc (cpJoint.c:116)
==27475==    by 0x66E267: cpPinJointNew (cpJoint.c:143)
==27475==    by 0x6416BC: Joint::loadToPlay(Level*, ChipmunkWorld*) (Entity.cpp:657)
==27475==    by 0x64EB18: Level::loadToPlay(ChipmunkWorld*, PhysicsSettings*, bool) (Level.cpp:1329)
==27475==    by 0x6591B7: Scene::_GenerateLevel(bool) (Scene.cpp:883)
==27475==    by 0x657D0C: Scene::prePlayLevel(DBuffer*, bool, bool, bool) (Scene.cpp:640)
==27475==    by 0x55A6E6: StatePreplayingGame::preloadLevels() (StatePreplayingGame.cpp:51)
==27475==    by 0x5570FA: StatePreplaying::enter() (StatePreplaying.cpp:142)
==27475==    by 0x52158F: StateManager::replaceState(GameState*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (StateManager.cpp:243)
==27475==    by 0x5655AB: StateScene::restartLevelToPlay(bool) (StateScene.cpp:1190)
==27475==    by 0x4E0774: StateDeadJust::restartLevel(bool) (StateDeadJust.cpp:118)
==27475==    by 0x4E064E: StateDeadJust::xmKey(InputEventType, XMKey const&) (StateDeadJust.cpp:101)
==27475==    by 0x523C48: StateManager::xmKey(InputEventType, XMKey const&) (StateManager.cpp:813)
==27475==    by 0x5A6F39: GameApp::manageEvent(SDL_Event*) (GameInit.cpp:735)
==27475==    by 0x5A781D: GameApp::run_loop() (GameInit.cpp:925)
==27475==    by 0x5A3888: GameApp::run(int, char**) (GameInit.cpp:158)
==27475==    by 0x5A36A2: main (GameInit.cpp:116)
==27475== 
```

</details>