### PR TITLE
msgmerge --sourt-output is obsolete option

### DIFF
--- a/i18n/gettextize
+++ b/i18n/gettextize
@@ -4,7 +4,7 @@
 cd ${0/gettextize/}/..
 SRCDIR=src
 SRC_FILES=($SRCDIR/xmoto/GameText.h $SRCDIR/xmoto/LevelsText.h)
-xgettext --default-domain xmoto --sort-output \
+xgettext --default-domain xmoto \
   --keyword=_ --keyword=ngettext \
   --add-comments=i18n -p ./i18n/po -o xmoto.pot \
   --package-name="X-Moto" \


### PR DESCRIPTION
building on arch linux gives:
--sort-output is an obsolete options.

see:
https://aur.archlinux.org/packages/xmoto